### PR TITLE
Release new FinnHub API version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Install Test Harness Dependencies
         run: |
           box install
+
       - name: Start ${{ matrix.cfengine }} Server
-        working-directory: ./tests
         run: |
           box server start cfengine=${{ matrix.cfengine }} port=60299 --noSaveSettings --debug
           curl http://127.0.0.1:60299
@@ -62,13 +62,13 @@ jobs:
         run: |
           mkdir tests/results
           box package set testbox.runner="http://localhost:60299/tests/runner.cfm"
-          box testbox run --verbose outputFile=tests/results outputFormats=json,antjunit
+          box testbox run --verbose outputFile=tests/results/result outputFormats=json,antjunit
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()
         with:
-          files: tests/results/**/*.xml
+          files: tests/results/*.xml
           check_name: "${{ matrix.cfengine }} Test Results"
 
       - name: Upload Test Results Artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ on:
       - development
       - master
 
-env:
-  MODULE_ID: finnhub
-
 jobs:
   #############################################
   # Tests First baby! We fail, no build :(
@@ -18,9 +15,6 @@ jobs:
     name: Tests
     if: "!contains(github.event.head_commit.message, '__SEMANTIC RELEASE VERSION UPDATE__')"
     runs-on: ubuntu-20.04
-    env:
-      DB_USER: root
-      DB_PASSWORD: root
     strategy:
       fail-fast: false
       matrix:
@@ -41,8 +35,8 @@ jobs:
           # Setup .env
           touch .env
           # ENV
-          #printf "FINNHUB_API_KEY=${{ env.FINNHUB_API_KEY }}\n" >> tests/.env
-          #printf "FINNHUB_API_URL=${{ env.FINNHUB_API_URL }}\n" >> tests/.env
+          #printf "FINNHUB_API_KEY=${{ secrets.FINNHUB_API_KEY }}\n" >> tests/.env
+          #printf "FINNHUB_API_URL=${{ secrets.FINNHUB_API_URL }}\n" >> tests/.env
 
       - name: Cache CommandBox Dependencies
         uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,17 +63,18 @@ jobs:
         run: |
           box server start cfengine=${{ matrix.cfengine }} port=60299 --noSaveSettings --debug
           curl http://127.0.0.1:60299
+
       - name: Run Tests
-        working-directory: ./tests
         run: |
-          mkdir results
+          mkdir tests/results
           box package set testbox.runner="http://localhost:60299/tests/runner.cfm"
-          box testbox run --verbose outputFile=results outputFormats=json,antjunit
+          box testbox run --verbose outputFile=tests/results outputFormats=json,antjunit
+
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()
         with:
-          files: tests/tests/results/**/*.xml
+          files: tests/results/**/*.xml
           check_name: "${{ matrix.cfengine }} Test Results"
 
       - name: Upload Test Results Artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 name: FinnHub CI
 
-# Only on Development we build snapshots
 on:
   push:
     branches:
       - development
       - master
+      - main
 
 jobs:
   #############################################
@@ -121,5 +121,5 @@ jobs:
       
       - name: Run Semantic Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: box semantic-release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
         uses: elpete/setup-commandbox@v1.0.0
 
       - name: Install Test Harness Dependencies
-        working-directory: ./tests
         run: |
           box install
       - name: Start ${{ matrix.cfengine }} Server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cfengine: [ "lucee@5", "adobe@2016", "adobe@2018", "adobe@2021" ]
+        cfengine: [ "lucee@5", "adobe@2018", "adobe@2021" ]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,9 @@ jobs:
       - name: Run Tests
         working-directory: ./tests
         run: |
-          mkdir tests/results
+          mkdir results
           box package set testbox.runner="http://localhost:60299/tests/runner.cfm"
-          box testbox run --verbose outputFile=tests/results outputFormats=json,antjunit
+          box testbox run --verbose outputFile=results outputFormats=json,antjunit
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,12 @@ jobs:
           java-version: "11"
 
       - name: Setup Environment For Testing Process
-        working-directory: ./tests
         run: |
           # Setup .env
           touch .env
           # ENV
-          #printf "FINNHUB_API_KEY=${{ secrets.FINNHUB_API_KEY }}\n" >> tests/.env
-          #printf "FINNHUB_API_URL=${{ secrets.FINNHUB_API_URL }}\n" >> tests/.env
+          printf "FINNHUB_API_KEY=${{ secrets.FINNHUB_API_KEY }}\n" >> .env
+          printf "FINNHUB_API_URL=${{ secrets.FINNHUB_API_URL }}\n" >> .env
 
       - name: Cache CommandBox Dependencies
         uses: actions/cache@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cfengine: [ "lucee@5", "adobe@2016", "adobe@2018", "adobe@2021" ]
+        cfengine: [ "lucee@5", "adobe@2018", "adobe@2021" ]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,10 +17,6 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-20.04
-    env:
-      MODULE_ID: finnhub
-      DB_USER: root
-      DB_PASSWORD: root
     strategy:
       fail-fast: false
       matrix:
@@ -41,8 +37,8 @@ jobs:
           # Setup .env
           touch .env
           # ENV
-          #printf "FINNHUB_API_KEY=${{ env.FINNHUB_API_KEY }}\n" >> tests/.env
-          #printf "FINNHUB_API_URL=${{ env.FINNHUB_API_URL }}\n" >> tests/.env
+          #printf "FINNHUB_API_KEY=${{ secrets.FINNHUB_API_KEY }}\n" >> tests/.env
+          #printf "FINNHUB_API_URL=${{ secrets.FINNHUB_API_URL }}\n" >> tests/.env
       - name: Setup CommandBox
         uses: elpete/setup-commandbox@v1.0.0
 
@@ -73,6 +69,7 @@ jobs:
         working-directory: ./tests
         run: |
           box server log serverConfigFile="server-${{ matrix.cfengine }}.json"
+
       - name: Upload Debugging Info To Artifacts
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,9 +58,9 @@ jobs:
       - name: Run Tests
         working-directory: ./tests
         run: |
-          mkdir tests/results
+          mkdir results
           box package set testbox.runner="http://localhost:60299/tests/runner.cfm"
-          box testbox run --verbose outputFile=tests/results outputFormats=json,antjunit
+          box testbox run --verbose outputFile=results outputFormats=json,antjunit
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,12 +54,13 @@ jobs:
         run: |
           box server start cfengine=${{ matrix.cfengine }} port=60299 --noSaveSettings --debug
           curl http://127.0.0.1:60299
+
       - name: Run Tests
-        working-directory: ./tests
         run: |
-          mkdir results
+          mkdir tests/results
           box package set testbox.runner="http://localhost:60299/tests/runner.cfm"
-          box testbox run --verbose outputFile=results outputFormats=json,antjunit
+          box testbox run --verbose outputFile=tests/results outputFormats=json,antjunit
+
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,13 +32,13 @@ jobs:
           java-version: "11"
 
       - name: Setup Environment For Testing Process
-        working-directory: ./tests
         run: |
           # Setup .env
           touch .env
           # ENV
-          #printf "FINNHUB_API_KEY=${{ secrets.FINNHUB_API_KEY }}\n" >> tests/.env
-          #printf "FINNHUB_API_URL=${{ secrets.FINNHUB_API_URL }}\n" >> tests/.env
+          printf "FINNHUB_API_KEY=${{ secrets.FINNHUB_API_KEY }}\n" >> .env
+          printf "FINNHUB_API_URL=${{ secrets.FINNHUB_API_URL }}\n" >> .env
+
       - name: Setup CommandBox
         uses: elpete/setup-commandbox@v1.0.0
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Install Dependencies
         run: |
           box install
+
       - name: Start ${{ matrix.cfengine }} Server
-        working-directory: ./tests
         run: |
           box server start cfengine=${{ matrix.cfengine }} port=60299 --noSaveSettings --debug
           curl http://127.0.0.1:60299
@@ -55,7 +55,7 @@ jobs:
         run: |
           mkdir tests/results
           box package set testbox.runner="http://localhost:60299/tests/runner.cfm"
-          box testbox run --verbose outputFile=tests/results outputFormats=json,antjunit
+          box testbox run --verbose outputFile=tests/results/result outputFormats=json,antjunit
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,7 +47,6 @@ jobs:
         uses: elpete/setup-commandbox@v1.0.0
 
       - name: Install Dependencies
-        working-directory: ./tests
         run: |
           box install
       - name: Start ${{ matrix.cfengine }} Server

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@
 
 # dependencies
 modules
+
+# Test artifacts
 tests/resources/app/coldbox
 tests/testbox
+tests/results


### PR DESCRIPTION
With the Github Actions build passing now on most CFML engines, I propose we push a new Forgebox release. :smile: 